### PR TITLE
2 Changes

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -2,5 +2,5 @@
 - hosts: tag_role_k8s_cluster
   become: true
   roles:
-    - ansible-role-docker
+    # - ansible-role-docker
     - kubernetes-deploy

--- a/roles/kubernetes-deploy/tasks/main.yml
+++ b/roles/kubernetes-deploy/tasks/main.yml
@@ -3,10 +3,10 @@
 
 - name: Perform a System Prep on Centos Atomic Host
   shell: |
-    sudo atomic host upgrade
-    sudo groupadd docker
-    sudo usermod -aG docker centos
-    sudo chown centos /var/run/docker.sock
+    atomic host upgrade
+    groupadd docker
+    usermod -aG docker centos
+    chown centos /var/run/docker.sock
     systemctl cat docker | grep -i mount
     mkdir /opt/cni /etc/cni
     chcon -Rt svirt_sandbox_file_t /etc/cni


### PR DESCRIPTION
* commenting out the docker role as Centos Atomic host has docker natively backed in a do not need this at the moment.
* Remove Sudo from shell module tasks.